### PR TITLE
Add basic OTA support

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -8,27 +8,45 @@
 ; Please visit documentation for the other options and examples
 ; https://docs.platformio.org/page/projectconf.html
 
-[env:ecoflow-1-0-0]
+
+[env]
 platform = espressif32
 board = firebeetle32
 framework = arduino
-upload_port = COM[3]
 upload_speed = 460800
-#upload_flags = --auth=admin
 board_build.partitions = partitions.csv
 board_build.f_flash = 80000000L
 board_build.flash_mode = qio
 monitor_speed = 115200
-build_type = debug
 
-monitor_filters = esp32_exception_decoder
-
-lib_deps = 
+lib_deps =
 	me-no-dev/ESP Async WebServer@^1.2.3
 	me-no-dev/ESPAsyncTCP@^1.2.2
-	
+	me-no-dev/AsyncTCP@^1.1.1
 	bblanchon/ArduinoJson@^6.20.1
 	adafruit/RTClib@^2.1.1
 	marian-craciunescu/ESP32Ping@^1.7
 	SPI
 	buelowp/sunset@^1.1.7
+
+# this is the target that is used by default when using pio run
+[env:debug]
+build_type = debug
+monitor_filters = esp32_exception_decoder
+
+# this target is for OTA upload
+[env:ota]
+build_type = debug
+monitor_filters = esp32_exception_decoder
+upload_flags = --auth=ecoflow-ota-password
+upload_port = ecoflow.local
+
+# this target is for OTA upload, release build
+[env:ota-release]
+build_type = release
+upload_flags = --auth=ecoflow-ota-password
+upload_port = ecoflow.local
+
+# a target for release / optimized code
+[env:release]
+build_type = release

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,6 +2,9 @@
 #include <WiFi.h>
 #include <ESPAsyncWebServer.h>
 #include <AsyncTCP.h>
+#include <ESPmDNS.h>
+#include <WiFiUdp.h>
+#include <ArduinoOTA.h>
 
 #include <freertos/FreeRTOS.h>
 #include <freertos/task.h>
@@ -34,4 +37,5 @@ void loop()
   // ----------   -------------------------------------   --------------------------
   // Core 1    -> g_TaskCore_1_Loop( void * pvParameters )   -> g_WebServer.handleClient()
   // core 0    -> g_TaskCore_0_Loop ( void * pvParameters )  -> call fncloopServosWithButtons
+  ArduinoOTA.handle();
 }

--- a/src/mainSetup.h
+++ b/src/mainSetup.h
@@ -6,6 +6,7 @@
 #include "ClsNetworkConfig.h"
 #include "mainSetupWebSrv.h"
 #include "mainSetupWifi.h"
+#include "mainSetupOTA.h"
 #include "mainSetupTimeSun.h"
 #include "mainSetupTasks.h"
 #include "web_html_root.h"
@@ -29,5 +30,6 @@ void fncMainSetup()
   fncMainSetupTimeSun();
   fncMainSetupRelays();
   fncMainSetupWebSrv();
+  fncMainSetupOTA();
 }
 #endif

--- a/src/mainSetupOTA.h
+++ b/src/mainSetupOTA.h
@@ -1,0 +1,20 @@
+#ifndef MAINSETUPOTA_H
+#define MAINSETUPOTA_H
+#include "mainDefines.h"
+
+#include <ArduinoOTA.h>
+#include <ESPmDNS.h>
+
+void fncMainSetupOTA()
+{
+  ArduinoOTA.setPort(3232);
+  // We need a form field to assign the host name, then
+  // the device can be accessed in the LAN as "$hostname.local", i.e. ecoflow.local
+  ArduinoOTA.setHostname("ecoflow");
+
+  // OTA updates can be protected with a password, we probably need a default
+  // password, but also a field in the web interface to change it.
+  ArduinoOTA.setPassword("ecoflow-ota-password");
+  ArduinoOTA.begin();
+}
+#endif


### PR DESCRIPTION
Can be used with:

`pio run -e ota --target upload`

This will target ecoflow.local on the LAN / Local Wifi

This also defines other environments like `debug` which is the default, and also `release`